### PR TITLE
Update main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,7 +7,7 @@ from torch.utils.data import Dataset, DataLoader
 from item2vec import Item2Vec
 
 def choose_with_prob(p_discard):
-    p = random.uniform()
+    p = np.random.uniform()
     return False if p < p_discard else True
 
 def sgns_sample_generator(train_seqs, vocabulary_size, context_window, discard=False):


### PR DESCRIPTION
numpy's random.uniform uses a default of 0 to 1 for bounds.  if you wish to use the `random` library, then the bounds must be specified, like `random.uniform(0,1)`.  Either works